### PR TITLE
Add support for iOS 10+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 # Generated files
 bin/
 gen/
-www/
 
 # Gradle files
 .gradle/

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,4 +27,14 @@
 
       <source-file src="src/android/CallTrap.java" target-dir="src/name/ratson/cordova/calltrap" />
     </platform>
+
+    <!-- iOS -->
+    <platform name="ios">
+        <config-file target="config.xml" parent="/*">
+            <feature name="CallTrap">
+                <param name="ios-package" value="CallTrack" />
+                <param name="onload" value="true" />
+            </feature>
+        </config-file>
+    </platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -36,5 +36,9 @@
                 <param name="onload" value="true" />
             </feature>
         </config-file>
+
+
+        <header-file src="src/ios/CallTrap.h" />
+        <source-file src="src/ios/CallTrap.m" />
     </platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -32,7 +32,7 @@
     <platform name="ios">
         <config-file target="config.xml" parent="/*">
             <feature name="CallTrap">
-                <param name="ios-package" value="CallTrack" />
+                <param name="ios-package" value="CallTrap" />
                 <param name="onload" value="true" />
             </feature>
         </config-file>

--- a/src/android/CallTrap.java
+++ b/src/android/CallTrap.java
@@ -1,7 +1,13 @@
 package name.ratson.cordova.calltrap;
 
+import android.Manifest;
 import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
+import android.support.v4.content.ContextCompat;
 import android.telephony.PhoneStateListener;
+import android.telephony.TelephonyCallback;
 import android.telephony.TelephonyManager;
 
 import org.apache.cordova.CallbackContext;
@@ -11,10 +17,14 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 
 public class CallTrap extends CordovaPlugin {
+    private static Logger log = Logger.getLogger(CallTrap.class.getName());
 
-    CallStateListener listener;
+    CallbackContextOwner listener;
 
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
@@ -27,14 +37,88 @@ public class CallTrap extends CordovaPlugin {
 
     private void prepareListener() {
         if (listener == null) {
-            listener = new CallStateListener();
-            TelephonyManager TelephonyMgr = (TelephonyManager) cordova.getActivity().getSystemService(Context.TELEPHONY_SERVICE);
-            TelephonyMgr.listen(listener, PhoneStateListener.LISTEN_CALL_STATE);
+            try {
+                TelephonyManager telephonyMgr = (TelephonyManager) cordova.getActivity().getSystemService(Context.TELEPHONY_SERVICE);
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    CallTrapCallStateListener callStateListener = new CallTrapCallStateListener();
+
+                    listener = callStateListener;
+                    boolean listeningAllowed = ContextCompat.checkSelfPermission(cordova.getActivity().getApplicationContext(), Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED;
+
+                    if (listeningAllowed) {
+                        telephonyMgr.registerTelephonyCallback(
+                                cordova.getActivity().getMainExecutor(),
+                                callStateListener
+                        );
+                    }
+                } else {
+                    CallTrapPhoneStateListener phoneStateListener = new CallTrapPhoneStateListener();
+
+                    listener = phoneStateListener;
+                    telephonyMgr.listen(
+                            phoneStateListener,
+                            PhoneStateListener.LISTEN_CALL_STATE
+                    );
+                }
+            } catch (SecurityException se) {
+                log.log(Level.SEVERE, "Couldn't setup call trap listener due to Security Exception - no calltrap events will be triggered", se);
+            }
         }
     }
 }
 
-class CallStateListener extends PhoneStateListener {
+interface CallbackContextOwner {
+    void setCallbackContext(CallbackContext context);
+}
+
+@RequiresApi(api = Build.VERSION_CODES.S)
+class CallTrapCallStateListener extends TelephonyCallback implements TelephonyCallback.CallStateListener, CallbackContextOwner {
+    private CallbackContext callbackContext;
+
+    public void setCallbackContext(CallbackContext context) {
+        this.callbackContext = context;
+    }
+
+    public void onCallStateChanged(int state) {
+        if (callbackContext == null) {
+            return;
+        }
+
+        String msg = "";
+
+        switch (state) {
+            case TelephonyManager.CALL_STATE_IDLE:
+                msg = "IDLE";
+                break;
+
+            case TelephonyManager.CALL_STATE_OFFHOOK:
+                msg = "OFFHOOK";
+                break;
+
+            case TelephonyManager.CALL_STATE_RINGING:
+                msg = "RINGING";
+                break;
+        }
+
+        JSONObject jsonObj = new JSONObject();
+
+        try {
+            jsonObj.put("state", msg);
+            jsonObj.put("number", null);
+        } catch (Exception e) {
+            System.out.println("Error: " + e);
+        }
+
+
+        PluginResult result = new PluginResult(PluginResult.Status.OK, jsonObj);
+        result.setKeepCallback(true);
+
+        callbackContext.sendPluginResult(result);
+    }
+}
+
+class CallTrapPhoneStateListener extends PhoneStateListener implements CallbackContextOwner {
 
     private CallbackContext callbackContext;
 

--- a/src/ios/CallTrap.h
+++ b/src/ios/CallTrap.h
@@ -1,0 +1,15 @@
+#import <CallKit/CallKit.h>
+#import <Cordova/CDVPlugin.h>
+
+@interface CallTrap : CDVPlugin<CXCallObserverDelegate>
+{
+    CXCallObserver *callObserverObj;
+    NSString *callbackId;
+}
+
+@property (nonatomic, strong) CXCallObserver *callObserverObj;
+@property (nonatomic, strong) NSString *callbackId;
+
+- (void)onCall:(CDVInvokedUrlCommand*)command;
+
+@end

--- a/src/ios/CallTrap.m
+++ b/src/ios/CallTrap.m
@@ -1,0 +1,59 @@
+#import "CallTrap.h"
+
+#import <CallKit/CallKit.h>
+
+@implementation CallTrap
+
+-(void)pluginInitialize
+{
+    CXCallObserver *callObserverObj = [[CXCallObserver alloc] init];
+    [callObserverObj setDelegate:self queue:nil]
+    self.callObserver = callObserverObj;
+    NSLog(@"Initialized CallTrap");
+}
+
+-(void)onReset
+{
+    self.callbackId = nil;
+    self.callObserver = nil;
+    NSLog(@"onReset of CallTrap called - resetting state");
+}
+
+- (void)onCall:(CDVInvokedUrlCommand*)command
+{
+    self.callbackId = command.callbackId;
+    NSLog(@"onCall of CallTrap called - setting callback ID");
+}
+
+- (void)callObserver:(CXCallObserver *)callObserver callChanged:(CXCall *)call {
+    NSString* callstatus = @"IDLE";
+
+    if (call == nil || call.hasEnded == YES) {
+        NSLog(@"CXCallState : Disconnected");
+        callstatus = @"IDLE";
+    }
+
+    if (call.isOutgoing == YES && call.hasConnected == NO) {
+        NSLog(@"CXCallState : Dialing");
+        callstatus = @"OFFHOOK";
+    }
+
+    if (call.isOutgoing == NO  && call.hasConnected == NO && call.hasEnded == NO && call != nil) {
+        NSLog(@"CXCallState : Incoming");
+        callstatus = @"RINGING";
+    }
+
+    if (call.hasConnected == YES && call.hasEnded == NO) {
+        NSLog(@"CXCallState : Connected");
+        callstatus = @"OFFHOOK";
+    }
+
+    NSMutableDictionary *resultData = [NSMutableDictionary dictionaryWithCapacity:2];
+    [resultData setObject:callstatus forKey:@"status"];
+    [resultData setObject:nil forKey:@"number"];
+
+    CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:resultData];
+    [self.commandDelegate sendPluginResult:result callbackId:self.callbackId];
+}
+
+@end

--- a/src/ios/CallTrap.m
+++ b/src/ios/CallTrap.m
@@ -15,8 +15,6 @@
 -(void)onReset
 {
     self.callbackId = nil;
-    self.callObserverObj = nil;
-    NSLog(@"onReset of CallTrap called - resetting state");
 }
 
 - (void)onCall:(CDVInvokedUrlCommand*)command
@@ -47,13 +45,24 @@
         NSLog(@"CXCallState : Connected");
         callstatus = @"OFFHOOK";
     }
+    
 
+    NSString *telephoneNrId = @"";
+    
+    if (call != nil && call.UUID != nil) {
+        telephoneNrId = call.UUID.UUIDString;
+    }
     NSMutableDictionary *resultData = [NSMutableDictionary dictionaryWithCapacity:2];
-    [resultData setObject:callstatus forKey:@"status"];
-    [resultData setObject:@"" forKey:@"number"];
+    [resultData setObject:callstatus forKey:@"state"];
+    [resultData setObject:telephoneNrId forKey:@"number"];
 
     CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:resultData];
-    [self.commandDelegate sendPluginResult:result callbackId:self.callbackId];
+    [result setKeepCallbackAsBool:YES];
+    
+    if (self.callbackId) {
+        [self.commandDelegate sendPluginResult:result callbackId:self.callbackId];
+        NSLog(@"Notify subscriber to CxCallState - state %@ - number %@", callstatus, telephoneNrId);
+    }
 }
 
 @end

--- a/src/ios/CallTrap.m
+++ b/src/ios/CallTrap.m
@@ -7,15 +7,15 @@
 -(void)pluginInitialize
 {
     CXCallObserver *callObserverObj = [[CXCallObserver alloc] init];
-    [callObserverObj setDelegate:self queue:nil]
-    self.callObserver = callObserverObj;
+    [callObserverObj setDelegate:self queue:nil];
+    self.callObserverObj = callObserverObj;
     NSLog(@"Initialized CallTrap");
 }
 
 -(void)onReset
 {
     self.callbackId = nil;
-    self.callObserver = nil;
+    self.callObserverObj = nil;
     NSLog(@"onReset of CallTrap called - resetting state");
 }
 
@@ -50,7 +50,7 @@
 
     NSMutableDictionary *resultData = [NSMutableDictionary dictionaryWithCapacity:2];
     [resultData setObject:callstatus forKey:@"status"];
-    [resultData setObject:nil forKey:@"number"];
+    [resultData setObject:@"" forKey:@"number"];
 
     CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:resultData];
     [self.commandDelegate sendPluginResult:result callbackId:self.callbackId];

--- a/www/CallTrap.js
+++ b/www/CallTrap.js
@@ -1,0 +1,28 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.STATE = undefined;
+exports.onCall = onCall;
+
+var _exec = require('cordova/exec');
+
+var _exec2 = _interopRequireDefault(_exec);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var STATE = exports.STATE = {
+  RINGING: 'RINGING',
+  OFFHOOK: 'OFFHOOK',
+  IDLE: 'IDLE'
+};
+
+function defaultErrorCallback() {
+  console.log("WARNING: CallTrap errorCallback not implemented");
+}
+
+function onCall(successCallback, errorCallback) {
+  errorCallback = errorCallback || defaultErrorCallback;
+  (0, _exec2.default)(successCallback, errorCallback, 'CallTrap', 'onCall', []);
+}


### PR DESCRIPTION
Extends current code base with an iOS implementation utilizing the relevant listeners from the Apple iOS CallKit.

Instead of the actual caller number the call UUID is provided which makes is used within iOS to query the caller details.

The state is mapped 1:1 to the Android states.

This is a drop-in extension which allows the same JS code to run now on iOS.